### PR TITLE
Check for existence of teardown/destroy methods to support ^Svelte 2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,15 +58,17 @@ module.exports = function SvelteStateRendererFactory(defaultOptions = {}) {
 				const svelte = context.domApi
 				const element = svelte.mountedToTarget
 
-				svelte.teardown()
+				svelte.teardown && svelte.teardown()
+				svelte.destroy && svelte.destroy()
 
 				const renderContext = Object.assign({ element }, context)
 
 				render(renderContext, cb)
 			},
 			destroy: function destroy(svelte, cb) {
-				svelte.teardown()
-				cb()
+                svelte.teardown && svelte.teardown()
+                svelte.destroy && svelte.destroy()
+                cb()
 			},
 			getChildElement: function getChildElement(svelte, cb) {
 				try {


### PR DESCRIPTION
Handle Svelte 2.0 which has removed the teardown method