### PR TITLE
Fix bug preventing `asr` prop from being reactive

### DIFF
--- a/index.svelte.js
+++ b/index.svelte.js
@@ -1,7 +1,7 @@
 import merge from 'deepmerge'
 import { mount, unmount } from 'svelte'
 
-export default function SvelteStateRendererFactory(defaultOptions = {}) {
+export default function SvelteStateRendererFactory({props: defaultProps, ...defaultOptions} = {}) {
 	return function makeRenderer(stateRouter) {
 		const asr = {
 			makePath: stateRouter.makePath,
@@ -13,7 +13,7 @@ export default function SvelteStateRendererFactory(defaultOptions = {}) {
 		async function render(context) {
 			const { element: target, template, content } = context
 
-			const props = $state(Object.assign(content, defaultOptions.props, { asr }))
+			const props = $state(Object.assign(content, defaultProps, { asr }))
 
 			const rendererSuppliedOptions = merge(defaultOptions, {
 				target,


### PR DESCRIPTION
After we construct the reactive `props` object, we merge it with the default options. However, if there was a `props` object on the `defaultOptions` object, it would break the reactivity by merging the reactive props object with the non-reactive default props object. Instead, separate the default props off to prevent that.