### PR TITLE
Svelte 5 HMR fix

### DIFF
--- a/index.svelte.js
+++ b/index.svelte.js
@@ -32,17 +32,6 @@ export default function SvelteStateRendererFactory({ props: defaultProps, ...def
 
 		return {
 			render,
-			reset: async function reset(context) {
-				const svelte = context.domApi
-				const element = svelte.mountedToTarget
-
-				svelte.asrOnDestroy()
-				unmount(svelte)
-
-				const renderContext = { element, ...context }
-
-				return render(renderContext)
-			},
 			destroy: async function destroy(svelte, { name }) {
 				stateInfo.get(name).asrOnDestroy()
 				stateInfo.delete(name)


### PR DESCRIPTION
Svelte 5 changed how HMR works, and now it removes the `asrOnDestroy` and `mountedToTarget` properties. So, store them on a Map instead. Also, remove the `reset` function since this requires ASR 8+, which doesn't call `reset` anymore.

HMR still won't work *perfectly* but it will at least not require a full page reload every time.